### PR TITLE
'twas throwing up a variable undefined error

### DIFF
--- a/Batch.roboFontExt/lib/variableFontGenerator/__init__.py
+++ b/Batch.roboFontExt/lib/variableFontGenerator/__init__.py
@@ -462,9 +462,9 @@ class BatchDesignSpaceProcessor(DesignSpaceProcessor):
                     # add the glyph to the master
                     master.newGlyph(glyphName)
                     glyph = master[glyphName]
-                    result.extractGlyph(master[glyphName], onlyGeometry=True)
+                    result.extractGlyph(glyph, onlyGeometry=True)
                     glyph.unicodes = list(result.unicodes)
-                    glyphs.append(master[glyphName])
+                    glyphs.append(glyph)
             # optimize glyph contour data from all masters
             self.makeGlyphOutlinesCompatible(glyphs)
         if getDefault("Batch.Debug", False):

--- a/Batch.roboFontExt/lib/variableFontGenerator/__init__.py
+++ b/Batch.roboFontExt/lib/variableFontGenerator/__init__.py
@@ -461,6 +461,7 @@ class BatchDesignSpaceProcessor(DesignSpaceProcessor):
                     self.generateReport.write("Adding missing glyph '%s' in master '%s %s (%s)'" % (glyphName, master.font.info.familyName, master.font.info.styleName, master.name))
                     # add the glyph to the master
                     master.newGlyph(glyphName)
+                    glyph = master[glyphName]
                     result.extractGlyph(master[glyphName], onlyGeometry=True)
                     glyph.unicodes = list(result.unicodes)
                     glyphs.append(master[glyphName])


### PR DESCRIPTION
The previous commit (would eventually) fix the missing unicodes issue but crashed when I tried to generate, so I think I tracked the error to here. That let me generate ok without losing the unicodes for missing glyphs.